### PR TITLE
Update 4to1mux_using_2to1mux_design.sv

### DIFF
--- a/Laboratorio1/Solución/Problema_2/4to1mux_using_2to1mux_design.sv
+++ b/Laboratorio1/Solución/Problema_2/4to1mux_using_2to1mux_design.sv
@@ -1,17 +1,24 @@
-module mux_4to1(A,B,C,D,S1,S2,OUT);
-  input A,B,C,D,S1,S2;
-  output OUT;
-  wire x1,x2;
-  
-  mux_2to1 m1(A,B,S1,x1);
-  mux_2to1 m2(C,D,S1,x2);
-  mux_2to1 m3(x1,x2,S2,OUT);
-  
-endmodule  
+`timescale 1ns / 1ps
 
-module mux_2to1(X,Y,S,Z);
-  input X,Y,S;
-  output Z;
-   
-  assign Z = (S== 1'b0) ? X : Y;
+module mux4x1 #(
+    parameter int W = 4   // Bit width
+) (
+    input  logic [W-1:0] A,
+    input  logic [W-1:0] B,
+    input  logic [W-1:0] C,
+    input  logic [W-1:0] D,
+    input  logic [1:0]   select,
+    output logic [W-1:0] mux_out
+);
+
+    always_comb begin
+        unique case (select)
+            2'b00 : mux_out = A;
+            2'b01 : mux_out = B;
+            2'b10 : mux_out = C;
+            2'b11 : mux_out = D;
+            default: mux_out = '0;  // SV shortcut for all zeros
+        endcase
+    end
+
 endmodule


### PR DESCRIPTION
`timescale 1ns / 1ps


module mux4x1 #(
    parameter int W = 4   // Bit width
) (
    input  logic [W-1:0] A,
    input  logic [W-1:0] B,
    input  logic [W-1:0] C,
    input  logic [W-1:0] D,
    input  logic [1:0]   select,
    output logic [W-1:0] mux_out
);

    always_comb begin
        unique case (select)
            2'b00 : mux_out = A;
            2'b01 : mux_out = B;
            2'b10 : mux_out = C;
            2'b11 : mux_out = D;
            default: mux_out = '0;  // SV shortcut for all zeros
        endcase
    end

endmodule
